### PR TITLE
more jitpack tweaks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,28 +1,35 @@
 plugins {
-    id 'java'
-    id 'application'
-    id 'maven-publish'
-    id 'com.github.johnrengelman.shadow' version '7.1.0'
+    id "java"
+    id "application"
+    id "maven-publish"
+    id "com.github.johnrengelman.shadow" version "7.1.0"
 }
 
-group 'org.example'
-version '1.0'
+group "org.example"
+version "0.1.0"
 mainClassName = "org.springframework.boot.loader.JarLauncher"
 sourceCompatibility = 11
-compileJava.options.encoding = 'UTF-8'
+compileJava.options.encoding = "UTF-8"
 
 repositories {
     mavenCentral()
-    maven { url 'https://jitpack.io' }
+    maven { url "https://jitpack.io" }
 
     // Transitive dependencies
-    maven { url 'https://m2.dv8tion.net/releases' }
+    maven { url "https://m2.dv8tion.net/releases" }
     jcenter()
 }
 
 dependencies {
-    implementation "dev.arbjerg.lavalink:plugin-api:0.7.0"
+    compileOnly "dev.arbjerg.lavalink:plugin-api:0.7.0"
     runtimeOnly "com.github.freyacodes.lavalink:Lavalink-Server:feature~plugins"
+}
+
+shadowJar {
+    def impl = project.configurations.implementation
+    impl.canBeResolved(true)
+    configurations = [impl]
+    archiveClassifier.set("")
 }
 
 publishing {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,4 @@
 jdk:
   - openjdk11
+install:
+  - ./gradlew clean shadowJar publishToMavenLocal -x jar


### PR DESCRIPTION
I had a nice chat with duncte and got the stuff to exclude lavalink server running

the plugin api should be compileOnly as the lavalink-server provides that

I also unified the `"` & `'`
if you prefer `'` let me know

here is the buildlog produced by jitpack: https://jitpack.io/com/github/TopiSenpai/lavalink-plugin-template/ed33813b74/build.log

auto download by lavalink also works!

```yaml
lavalink:
  plugins:
    - dependency: "com.github.topisenpai:lavalink-plugin-template:ed33813b74"
      repository: "https://jitpack.io"
```
